### PR TITLE
One more useful tidbit while using here documents.

### DIFF
--- a/bash-redirections-cheat-sheet.txt
+++ b/bash-redirections-cheat-sheet.txt
@@ -46,6 +46,11 @@
 | baz                         |                                             |
 | EOL                         |                                             |
 +-----------------------------'---------------------------------------------'
+| cmd <<- EOL                 |                                             |
+| <tab>foo                    | Redirect a bunch of lines to the stdin.     |
+| <tab>bar                    | The <tab>'s are ignored but not the         |
+| EOL                         | whitespace.  Helpful for formatting         |
++-----------------------------'---------------------------------------------'
 | cmd <<< "string"            | Redirect a single line of text to stdin.    |
 +-----------------------------'---------------------------------------------'
 | exec 2> file                | Redirect stderr of all commands to a file   |


### PR DESCRIPTION
The <<- here document will ignore leading tabs but preserve spaces.

This technique is helpful for maintaining easy to read bash scripts.
