### PR TITLE
Added <(cmd) redirect

### DIFF
--- a/bash-redirections-cheat-sheet.tex
+++ b/bash-redirections-cheat-sheet.tex
@@ -110,6 +110,8 @@
 \hline
 \verb|cmd > >(cmd1) 2> >(cmd2)| & Send stdout of \verb|cmd| to \verb|cmd1| and stderr of \verb|cmd| to \verb|cmd2|. \\
 \hline
+\verb|cmd <(cmd1) <(cmd2)| & Send stdouts of \verb|cmd1| and \verb|cmd2| to descriptors, giving descriptor names to \verb|cmd|. \\
+\hline
 \verb/cmd1 | cmd2 | cmd3 | cmd4/ \par
 \verb/echo ${PIPESTATUS[@]}/ & Find out the exit codes of all piped commands. \\
 \hline


### PR DESCRIPTION
This is my favorite Bash redirect, so I was surprised it was missing! `<(cmd)` turns the stdout of a command into something that looks like a file to another command.

I don't know how you're generating the `.txt` and `.png` files, so I only included the change to the `.tex` file in this commit.
